### PR TITLE
deps: use upstream ring 0.16.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ trust_anchor_util = ["std"]
 std = []
 
 [dependencies]
-ring = { git = "https://github.com/jmagnuson/ring", branch = "support-1024-bit-rsa" }
+ring = "0.16.11"
 untrusted = "0.7.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Now that 1024 bit RSA support is added into ring 0.16.11, my forked copy
can be dropped in favor of upstream.